### PR TITLE
./gradlew bootRunの引数でプロファイルを変更できるように変更

### DIFF
--- a/profile-driven/build.gradle
+++ b/profile-driven/build.gradle
@@ -30,3 +30,5 @@ dependencies {
 
     compileOnly('org.projectlombok:lombok')
 }
+
+bootRun.systemProperties = System.properties


### PR DESCRIPTION
`./gradlew bootRun` でプロファイルを変更して動かすことができるようになってるほうが便利そうなので、 `build.gradle` の `bootRun` タスクのプロパティに実行時のプロパティを差し込むようにしてみました。

以下のように実行可能になります。
```
$ ./gradlew bootRun -Dspring.profiles.active=foo
```